### PR TITLE
Python 3.10 Updates

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ verify_ssl = true
 [packages]
 numpy = "*"
 scikit-image = "*"
-attrdict = "*"
 gitpython = "*"
 pyqt5 = "*"
 matplotlib = "*"

--- a/baseline_requirements.txt
+++ b/baseline_requirements.txt
@@ -1,4 +1,3 @@
-attrdict
 GitPython
 numpy>=1.20.0
 pybullet>=2.7.1

--- a/bulletarm/envs/base_env.py
+++ b/bulletarm/envs/base_env.py
@@ -925,7 +925,7 @@ class BaseEnv:
 
     primitive_idx, x_idx, y_idx, z_idx, rot_idx = map(lambda a: self.action_sequence.find(a),
                                                       ['p', 'x', 'y', 'z', 'r'])
-    action = np.zeros(len(self.action_sequence), dtype=np.float)
+    action = np.zeros(len(self.action_sequence), dtype=float)
     if primitive_idx != -1:
       action[primitive_idx] = primitive
     if x_idx != -1:

--- a/bulletarm/pybullet/robots/ur5_robotiq.py
+++ b/bulletarm/pybullet/robots/ur5_robotiq.py
@@ -4,7 +4,6 @@ import math
 import numpy as np
 import numpy.random as npr
 from collections import deque, namedtuple
-from attrdict import AttrDict
 from threading import Thread
 
 import pybullet as pb
@@ -61,7 +60,7 @@ class UR5_Robotiq(RobotBase):
       "robotiq_85_right_finger_tip_joint"
     ]
     self.robotiq_mimic_multiplier = [1, 1, 1, 1, -1, -1]
-    self.robotiq_joints = AttrDict()
+    self.robotiq_joints = {}
 
   def initialize(self):
     ''''''

--- a/docs/env.yaml
+++ b/docs/env.yaml
@@ -18,7 +18,6 @@ dependencies:
   - scikit-image
   - scikit-learn
   - gitpython
-  - attrdict
   - tqdm
   - matplotlib
   - pytorch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-attrdict
 GitPython
 numpy>=1.19.5
 pybullet>=2.7.1


### PR DESCRIPTION
Changes to Python 3.10 means that the module `AttrDict` doesn't work anymore (last update was in 2019). Also, with `Numpy` 1.24 they no longer have module specific data types.
This PR removes the dependency on `AttrDict` (which it wasn't using functionality of anyways) and removes the numpy float usage. 